### PR TITLE
add sensor for alerts from alertmanager

### DIFF
--- a/sensors/alertmanager_sensor.py
+++ b/sensors/alertmanager_sensor.py
@@ -27,7 +27,7 @@ class AlertmanagerSensor(Sensor):
           d = json.loads(s)
           labels = d['alerts'][0]['labels']
 
-          trigger = 'default.prometheus.alert'
+          trigger = 'prometheus.alert'
           payload = {
             'alert_name': labels['alertname'],
             'host': labels['host']

--- a/sensors/alertmanager_sensor.py
+++ b/sensors/alertmanager_sensor.py
@@ -1,0 +1,61 @@
+from st2reactor.sensor.base import Sensor
+
+import BaseHTTPServer
+from BaseHTTPServer import BaseHTTPRequestHandler
+
+import urllib
+import json
+import traceback
+
+class AlertmanagerSensor(Sensor):
+  def __init__(self, sensor_service, config):
+    super(AlertmanagerSensor, self).__init__(sensor_service=sensor_service, config=config)
+    self._logger = self.sensor_service.get_logger(name=self.__class__.__name__)
+    self._host = '0.0.0.0'
+    self._port = 12345
+
+  def _create_handler_class(sensor):
+    class AlertmanagerHandler(BaseHTTPRequestHandler):
+      def __init__(self, *args, **kwargs):
+        self._sensor = sensor
+        BaseHTTPRequestHandler.__init__(self, *args, **kwargs)
+
+      def do_POST(self):
+        length = int(self.headers.getheader('content-length', 0))
+        s = urllib.unquote(self.rfile.read(length))
+        try:
+          d = json.loads(s)
+          labels = d['alerts'][0]['labels']
+
+          trigger = 'default.prometheus.alert'
+          payload = {
+            'alert_name': labels['alertname'],
+            'host': labels['host']
+          }
+          self._sensor.sensor_service.dispatch(trigger=trigger, payload=payload)
+
+          self.send_response(200)
+        except Exception as e:
+          self._sensor._logger.error(e)
+          self._sensor._logger.error(traceback.format_exc())
+          self.send_response(400)
+    return AlertmanagerHandler
+
+  def setup(self):
+    handler_class = self._create_handler_class()
+    self._http_server = BaseHTTPServer.HTTPServer((self._host, self._port), handler_class)
+
+  def run(self):
+    self._http_server.serve_forever()
+
+  def cleanup(self):
+    self._http_server.server_close()
+
+  def add_trigger(self, trigger):
+    pass
+
+  def update_trigger(self, trigger):
+    pass
+
+  def remove_trigger(self, trigger):
+    pass

--- a/sensors/alertmanager_sensor.yaml
+++ b/sensors/alertmanager_sensor.yaml
@@ -1,0 +1,17 @@
+---
+class_name: AlertmanagerSensor
+entry_point: alertmanager_sensor.py
+description: "Receives information about new alerts from Alertmanager and creates triggers"
+trigger_types:
+  -
+    name: "prometheus.alert"
+    description: "Represents a single alert from Prometheus/Alertmanager"
+    payload_schema:
+      type: "object"
+      properties:
+        alert_name:
+          type: "string"
+        host:
+          type: "string"
+        service:
+          type: "string"


### PR DESCRIPTION
This sensor listens on port 12345 for webhooks sent from Alertmanager
and creates prometheus.alert triggers that rules can use.

It's assumed that the alertname and host labels exist on the event.