### PR TITLE
ITDEV-6263: iterate over all alerts in payload

### DIFF
--- a/sensors/alertmanager_sensor.py
+++ b/sensors/alertmanager_sensor.py
@@ -25,14 +25,14 @@ class AlertmanagerSensor(Sensor):
         s = self.rfile.read(length)
         try:
           d = json.loads(s)
-          labels = d['alerts'][0]['labels']
-
-          trigger = 'prometheus.alert'
-          payload = {
-            'alert_name': labels['alertname'],
-            'host': labels['instance']
-          }
-          self._sensor.sensor_service.dispatch(trigger=trigger, payload=payload)
+          for alert in d['alerts']:
+            labels = alerts['labels']
+            trigger = 'prometheus.alert'
+            payload = {
+              'alert_name': labels['alertname'],
+              'host': labels['instance']
+            }
+            self._sensor.sensor_service.dispatch(trigger=trigger, payload=payload)
 
           self.send_response(200)
           self.send_header("Content-type", "application/json")


### PR DESCRIPTION
It turns out that Alertmanager will group together alerts into a single
HTTP POST even if alert grouping is disabled. This makes sense and I
shouldn't have only cared about the first alert in the first place. Oh
well.